### PR TITLE
Fix build error of two-way offset road

### DIFF
--- a/core/assets.py
+++ b/core/assets.py
@@ -93,7 +93,7 @@ class Asset():
         return self.roadtype == 'b' and self.center() == [0,0]
 
     def reverse(self):
-        return Asset(self.xleft[1], self.nlanes[1], self.xleft[0], self.nlanes[0], self.medians)
+        return Asset(self.xleft[1], self.nlanes[1], self.xleft[0], self.nlanes[0], self.medians[::-1])
 
     def always_undivided(self):
         return self.xleft[0] == 0 and self.xleft[1] == 0


### PR DESCRIPTION
Using tool to build the road `8DC=4DC4DR4P`, but the output road is `8DC=2R44DC2R4P`.